### PR TITLE
Use clear-cache operation including site and namespace

### DIFF
--- a/pipelines/budgets_execution/Jenkinsfile
+++ b/pipelines/budgets_execution/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
         }
         stage('Clear cache') {
           steps {
-            sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb"
+            sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb --site-organization-id '${ESPLUGUES_ID}' --namespace 'GobiertoBudgets'"
           }
         }
     }

--- a/pipelines/budgets_execution/dev_run.sh
+++ b/pipelines/budgets_execution/dev_run.sh
@@ -6,16 +6,17 @@ XBRL_FILE="AJ-TrimLoc-2020_1t.xbrl"
 YEAR=2020
 WORKING_DIR=/tmp/esplugues
 GOBIERTO_ETL_UTILS=$DEV_DIR/gobierto-etl-utils
+ESPLUGUES_ID=8077
 
 # Extract > Download data sources
 cd $GOBIERTO_ETL_UTILS; ruby operations/download-s3/run.rb "esplugues/budgets/$XBRL_FILE" $WORKING_DIR/
 
-cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/xbrl/trimloc/transform-execution/run.rb operations/gobierto_budgets/xbrl/dictionaries/xbrl_trimloc_dictionary.yml $WORKING_DIR/$XBRL_FILE 8077 $YEAR $WORKING_DIR/budgets-execution-$YEAR.json
+cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/xbrl/trimloc/transform-execution/run.rb operations/gobierto_budgets/xbrl/dictionaries/xbrl_trimloc_dictionary.yml $WORKING_DIR/$XBRL_FILE $ESPLUGUES_ID $YEAR $WORKING_DIR/budgets-execution-$YEAR.json
 
 cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/import-executed-budgets/run.rb $WORKING_DIR/budgets-execution-$YEAR.json $YEAR
 
 # Load > Calculate totals
-echo "8077" > $WORKING_DIR/organization.id.txt
+echo "$ESPLUGUES_ID" > $WORKING_DIR/organization.id.txt
 cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/update_total_budget/run.rb $YEAR $WORKING_DIR/organization.id.txt
 
 # Load > Calculate bubbles
@@ -28,4 +29,4 @@ cd $DEV_DIR/gobierto/; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto_
 cd $DEV_DIR/gobierto/; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/publish-activity/run.rb budgets_updated $WORKING_DIR/organization.id.txt
 
 # Clear cache
-cd $DEV_DIR/gobierto; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/clear-cache/run.rb
+cd $DEV_DIR/gobierto; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/clear-cache/run.rb --site-organization-id "$ESPLUGUES_ID" --namespace "GobiertoBudgets"

--- a/pipelines/budgets_planned/Jenkinsfile
+++ b/pipelines/budgets_planned/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
         }
         stage('Clear cache') {
           steps {
-            sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb"
+            sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb --site-organization-id '${ESPLUGUES_ID}' --namespace 'GobiertoBudgets'"
           }
         }
     }

--- a/pipelines/budgets_planned/dev_run.sh
+++ b/pipelines/budgets_planned/dev_run.sh
@@ -5,21 +5,22 @@ set -e
 YEAR=2020
 WORKING_DIR=/tmp/esplugues
 GOBIERTO_ETL_UTILS=$DEV_DIR/gobierto-etl-utils
+ESPLUGUES_ID=8077
 
 # Extract > Download data sources
 XBRL_FILE="08077AA000-Penloc-2020.xbrl"
 cd $GOBIERTO_ETL_UTILS; ruby operations/download-s3/run.rb "esplugues/budgets/$XBRL_FILE" $WORKING_DIR/
-cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/xbrl/penloc/transform-planned/run.rb operations/gobierto_budgets/xbrl/dictionaries/xbrl_penloc_dictionary.yml $WORKING_DIR/$XBRL_FILE 8077 $YEAR $WORKING_DIR/budgets-planned-$YEAR.json
+cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/xbrl/penloc/transform-planned/run.rb operations/gobierto_budgets/xbrl/dictionaries/xbrl_penloc_dictionary.yml $WORKING_DIR/$XBRL_FILE $ESPLUGUES_ID $YEAR $WORKING_DIR/budgets-planned-$YEAR.json
 cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/import-planned-budgets/run.rb $WORKING_DIR/budgets-planned-$YEAR.json $YEAR
 
 # Extract > Download data sources
 XBRL_FILE="AJ-TrimLoc-2020_1t.xbrl"
 cd $GOBIERTO_ETL_UTILS; ruby operations/download-s3/run.rb "esplugues/budgets/$XBRL_FILE" $WORKING_DIR/
-cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/xbrl/trimloc/transform-planned/run.rb operations/gobierto_budgets/xbrl/dictionaries/xbrl_trimloc_dictionary.yml $WORKING_DIR/$XBRL_FILE 8077 $YEAR $WORKING_DIR/budgets-planned-$YEAR.json
+cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/xbrl/trimloc/transform-planned/run.rb operations/gobierto_budgets/xbrl/dictionaries/xbrl_trimloc_dictionary.yml $WORKING_DIR/$XBRL_FILE $ESPLUGUES_ID $YEAR $WORKING_DIR/budgets-planned-$YEAR.json
 cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/import-planned-budgets/run.rb $WORKING_DIR/budgets-planned-$YEAR.json $YEAR
 
 # Load > Calculate totals
-echo "8077" > $WORKING_DIR/organization.id.txt
+echo "$ESPLUGUES_ID" > $WORKING_DIR/organization.id.txt
 cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/update_total_budget/run.rb $YEAR $WORKING_DIR/organization.id.txt
 
 # Load > Calculate bubbles
@@ -32,4 +33,4 @@ cd $DEV_DIR/gobierto/; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto_
 cd $DEV_DIR/gobierto/; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/publish-activity/run.rb budgets_updated $WORKING_DIR/organization.id.txt
 
 # Clear cache
-cd $DEV_DIR/gobierto; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/clear-cache/run.rb
+cd $DEV_DIR/gobierto; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/clear-cache/run.rb --site-organization-id "$ESPLUGUES_ID" --namespace "GobiertoBudgets"

--- a/pipelines/budgets_planned_updated/Jenkinsfile
+++ b/pipelines/budgets_planned_updated/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
         }
         stage('Clear cache') {
           steps {
-            sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb"
+            sh "cd ${GOBIERTO}; bin/rails runner ${GOBIERTO_ETL_UTILS}/operations/gobierto/clear-cache/run.rb --site-organization-id '${ESPLUGUES_ID}' --namespace 'GobiertoBudgets'"
           }
         }
     }

--- a/pipelines/budgets_planned_updated/dev_run.sh
+++ b/pipelines/budgets_planned_updated/dev_run.sh
@@ -6,16 +6,17 @@ XBRL_FILE="AJ-TrimLoc-2020_1t.xbrl"
 YEAR=2020
 WORKING_DIR=/tmp/esplugues
 GOBIERTO_ETL_UTILS=$DEV_DIR/gobierto-etl-utils
+ESPLUGUES_ID=8077
 
 # Extract > Download data sources
 cd $GOBIERTO_ETL_UTILS; ruby operations/download-s3/run.rb "esplugues/budgets/$XBRL_FILE" $WORKING_DIR/
 
-cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/xbrl/trimloc/transform-planned-updated/run.rb operations/gobierto_budgets/xbrl/dictionaries/xbrl_trimloc_dictionary.yml $WORKING_DIR/$XBRL_FILE 8077 $YEAR $WORKING_DIR/budgets-planned-updated-$YEAR.json
+cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/xbrl/trimloc/transform-planned-updated/run.rb operations/gobierto_budgets/xbrl/dictionaries/xbrl_trimloc_dictionary.yml $WORKING_DIR/$XBRL_FILE $ESPLUGUES_ID $YEAR $WORKING_DIR/budgets-planned-updated-$YEAR.json
 
 cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/import-planned-budgets-updated/run.rb $WORKING_DIR/budgets-planned-updated-$YEAR.json $YEAR
 
 # Load > Calculate totals
-echo "8077" > $WORKING_DIR/organization.id.txt
+echo "$ESPLUGUES_ID" > $WORKING_DIR/organization.id.txt
 cd $GOBIERTO_ETL_UTILS; ruby operations/gobierto_budgets/update_total_budget/run.rb $YEAR $WORKING_DIR/organization.id.txt
 
 # Load > Calculate bubbles
@@ -28,4 +29,4 @@ cd $DEV_DIR/gobierto/; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto_
 cd $DEV_DIR/gobierto/; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/publish-activity/run.rb budgets_updated $WORKING_DIR/organization.id.txt
 
 # Clear cache
-cd $DEV_DIR/gobierto; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/clear-cache/run.rb
+cd $DEV_DIR/gobierto; bin/rails runner $GOBIERTO_ETL_UTILS/operations/gobierto/clear-cache/run.rb --site-organization-id "$ESPLUGUES_ID" --namespace "GobiertoBudgets"


### PR DESCRIPTION
Related to PopulateTools/issues#1439

This PR replaces the clear-cache operation call and includes site and namespace arguments